### PR TITLE
refactor: conventional commits configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 repos:
   - repo: https://github.com/commitizen-tools/commitizen
-    rev: v4.12.1  # Replace with latest tag
+    rev: v4.12.1
     hooks:
       - id: commitizen
       - id: commitizen-branch


### PR DESCRIPTION
This pull request contains a minor change to the `.pre-commit-config.yaml` file, specifically removing an outdated comment about updating the `commitizen` version tag.