### PR TITLE
feat: package-mode to false in pyproject.toml configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,15 @@
----
 repos:
   - repo: https://github.com/commitizen-tools/commitizen
-    rev: v4.12.1
+    rev: "v4.12.1"
     hooks:
       - id: commitizen
+        stages: [commit-msg]
       - id: commitizen-branch
         stages: [pre-push]
+
+  - repo: https://github.com/python-poetry/poetry
+    rev: "2.3.1"
+    hooks:
+      - id: poetry-check
+      - id: poetry-lock
+      - id: poetry-install

--- a/poetry.lock
+++ b/poetry.lock
@@ -205,5 +205,5 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 
 [metadata]
 lock-version = "2.1"
-python-versions = ">=3.14"
-content-hash = "d66f63901f08509420a235909a6265ea5e325fb189dd16dc76630cb94580310a"
+python-versions = ">=3.14,<4.0"
+content-hash = "29b77a6e6c010720136376d7b9f7f9a967a886b8428279d32a9e2bac75b39860"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,12 +7,12 @@ authors = [
 ]
 license = "Apache-2.0"
 readme = "README.md"
-requires-python = ">=3.14"
+requires-python = ">=3.14,<4.0"
 dependencies = [
 ]
 
 [tool.poetry]
-packages = [{include = "osm_health_check", from = "src"}]
+package-mode = false
 
 [build-system]
 requires = ["poetry-core>=2.0.0,<3.0.0"]
@@ -20,5 +20,5 @@ build-backend = "poetry.core.masonry.api"
 
 [dependency-groups]
 dev = [
-    "pre-commit (>=4.5.1,<5.0.0)"
+    "pre-commit (>=4.5.1,<5.0.0)",
 ]


### PR DESCRIPTION
This pull request updates project configuration files to improve dependency management and pre-commit hook setup. The main changes involve adding Poetry-related pre-commit hooks and refining Python version requirements and Poetry settings.

**Pre-commit hook improvements:**
* Added new hooks for Poetry (`poetry-check`, `poetry-lock`, `poetry-install`) in `.pre-commit-config.yaml` to automate dependency checks and installations.
* Explicitly set the `commitizen` hook to run at the `commit-msg` stage, clarifying when it is triggered.

**Poetry and dependency configuration:**
* Updated the Python version requirement in `pyproject.toml` to restrict it to versions `>=3.14,<4.0`, ensuring compatibility.
* Changed Poetry's configuration from `packages` to `package-mode = false`, reflecting a shift in how the package is managed.
* Minor formatting fix in the dev dependency group for `pre-commit` in `pyproject.toml`.