### PR TITLE
fix: avoid the Initial Commit message and update versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,9 +6,12 @@ repos:
         stages: [commit-msg]
       - id: commitizen-branch
         stages: [pre-push]
+        args:
+          - --rev-range
+          - origin/main..HEAD
 
   - repo: https://github.com/python-poetry/poetry
-    rev: "2.3.1"
+    rev: "2.3.2"
     hooks:
       - id: poetry-check
       - id: poetry-lock


### PR DESCRIPTION
This pull request makes minor updates to the `.pre-commit-config.yaml` file, improving the configuration for pre-push checks and updating the Poetry dependency.

Most important changes:

Pre-push hook configuration:

* Added `--rev-range origin/main..HEAD` arguments to the `commitizen-branch` pre-push hook to ensure it only checks commits not yet on `main`.

Dependency update:

* Updated the Poetry version from `2.3.1` to `2.3.2` to use the latest features and bug fixes.